### PR TITLE
fix: delete zero-byte cache files on load instead of leaving stale locks

### DIFF
--- a/src/DynamicObjects.jl
+++ b/src/DynamicObjects.jl
@@ -491,7 +491,10 @@ _computeproperty(o, name, indices...; __status__=nothing, kwargs...) = begin
                     nothing
                 end
             else
-                cache_status == :started && @warn "Cache file $cache_path exists but has size 0.\nAssuming a previous run failed."
+                if cache_status == :started
+                    @warn "Cache file $cache_path exists but has size 0. Removing and recomputing."
+                    rm(cache_path)
+                end
                 touch(cache_path)
                 nothing
             end


### PR DESCRIPTION
## Summary

When a computation is interrupted mid-write (process kill, OOM, crash), the cache file is left as a zero-byte placeholder. `get_cache_status` returns `:started` for these files.

The current handling warns but leaves the file in place, which means subsequent recomputation attempts also fail — the zero-byte file acts as a permanent lock requiring manual deletion.

## Relation to 5185bd5

Commit 5185bd5 ("retry after deserialization failure") handles corrupted **non-empty** files that fail to deserialize. This PR handles the complementary case: **zero-byte** files left by interrupted writes.

| Case | 5185bd5 | This PR |
|---|---|---|
| Non-empty file, deserialization error | ✅ delete + retry | — |
| Zero-byte file (`:started` status) | ✗ warns, leaves file | ✅ delete + retry |

Together they cover both failure modes cleanly.

## Change

```julia
# Before
cache_status == :started && @warn "Cache file $cache_path exists but has size 0.\nAssuming a previous run failed."
touch(cache_path)

# After
if cache_status == :started
    @warn "Cache file $cache_path exists but has size 0. Removing and recomputing."
    rm(cache_path)
end
touch(cache_path)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)